### PR TITLE
Added mandatory selector parameter to defaults

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ install:
 # command to run tests
 script:
   - flake8 . --max-line-length=120
-  - pep257 . --ignore=D202
+  - pep257 . --ignore=D202 --ignore=D211

--- a/linter.py
+++ b/linter.py
@@ -17,7 +17,6 @@ class Checkpatch(Linter):
 
     """Provides an interface to linux kernel 'checkpatch.pl' tool."""
 
-    syntax = 'c'
     cmd = 'checkpatch.pl -f @'
     executable = None
     version_re = r'Version: (?P<version>\d+\.\d+)'
@@ -26,7 +25,8 @@ class Checkpatch(Linter):
     tempfile_suffix = 'c'
 
     defaults = {
-        '--root=': '/path/to/kernel/source/tree'
+        '--root=': '/path/to/kernel/source/tree',
+        'selector': 'source.c, source.h'
     }
 
     # Here is several sample error/warning output:
@@ -59,7 +59,6 @@ class Checkpatch(Linter):
 
     def split_match(self, match):
         """Extract and return values from match."""
-
         match, line, col, error, warning, message, near = super().split_match(match)
 
         if match:


### PR DESCRIPTION
SublimeLinter requires the selector parameter to be set in the defaults now. 
This PR just add the required parameter and removes the deprecated syntax setting.  

(Thanks for this plugin!)

